### PR TITLE
Fix the bug deleting visibilities when `static`

### DIFF
--- a/lib/PublicVisibility.php
+++ b/lib/PublicVisibility.php
@@ -160,7 +160,7 @@ class PublicVisibility extends AbstractFixer
                 'static'     => null,
             ]
         );
-        if ($result['visibility'] && $result['visibility']->getContent('public')) {
+        if ($result['visibility'] && 'public' === $result['visibility']->getContent()) {
             // If visibility is public and static is set, we remove visibility.
             if ($result['static']) {
                 $result['visibility'] = null;


### PR DESCRIPTION
Fix #16.

When we have:

``` php
protected static $attr;
```

or

``` php
private static $attr;
```

it is simplified to:

``` php
static $attr;
```

which is obviously wrong and dangerous. We fix this bug. It is
simplified on when the visibility is `public`.
